### PR TITLE
include new function for using tiff.js rather than tiff-js skip ci

### DIFF
--- a/caniprintit-resources/assets/public/js/common.js
+++ b/caniprintit-resources/assets/public/js/common.js
@@ -6,7 +6,8 @@ require.config({
         'vow': 'vendor/vow/lib/vow',
         'bacon': 'vendor/bacon/dist/Bacon',
         'bacon.jquery': 'vendor/bacon.jquery/dist/bacon.jquery',
-        'bacon.model': 'vendor/bacon.model/dist/bacon.model'
+        'bacon.model': 'vendor/bacon.model/dist/bacon.model',
+        'tiff': 'vendor/tiff'
     },
     shim: {
         'bootstrap': {

--- a/caniprintit-resources/assets/public/js/filereader/getImageDimensions.js
+++ b/caniprintit-resources/assets/public/js/filereader/getImageDimensions.js
@@ -2,7 +2,7 @@
  * Loads an image from a JavaScript File object and returns a promise yielding the dimensions
  * as 'height' and 'width'. We are not currently attempting to display a thumbnail of the image.
  */
-define(['vow', 'tiff-js/TIFFParser'], function(vow, TIFFParser) {
+define(['vow', 'tiff'], function(vow, TIFFParser) {
     'use strict';
 
     function readNative(blob, resolve, reject) {
@@ -33,9 +33,8 @@ define(['vow', 'tiff-js/TIFFParser'], function(vow, TIFFParser) {
         var reader = new FileReader();
 
         reader.onload = function(e) {
-            var parser = new TIFFParser();
-            var canvas = parser.parseTIFF(e.target.result);
-            resolve(canvas);
+            var parser = new Tiff({buffer: e.target.result})
+            resolve({ width: parser.width(), height: parser.height() });
         };
 
         reader.onerror = function(e) {


### PR DESCRIPTION
@chrylis this: https://raw.githubusercontent.com/seikichi/tiff.js/master/tiff.js is what i downloaded and included in vendor, and have changed line 1009 to increase the memory. You have better knowledge of this stuff, so i'll leave memory allocation to you, as well as how we would like to include this module. 
